### PR TITLE
Relative URL Fixes in exports and data libraries

### DIFF
--- a/client/js/library.js
+++ b/client/js/library.js
@@ -342,10 +342,11 @@ var AssetRowView = Backbone.View.extend({
         this.render();
     },
     render: function() {
+        var absurl = this.model.get('url');
         $(this.el).html(ich.AssetRowView({
             id: this.model.id,
             bytes: this.model.get('bytes'),
-            url: this.model.get('url'),
+            url: absurl.slice(absurl.indexOf('api')),
             type: this.model.extension()
         }));
         return this;


### PR DESCRIPTION
Hi,
I am running Tilemill behind a gateway (Apache mod_proxy) and had to fix those to prevent absolute URLs on frontend.
Mathieu.
