### PR TITLE
Correct git repository URL.

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,10 +5,10 @@
     "description": "A modern map design studio.",
     "keywords": ["map", "design", "cartography"],
     "url": "http://github.com/developmentseed/tilemill",
-    "repositories": [{
+    "repository": {
         "type": "git",
-        "url": "git://github.com/developmentseed/tilemill.git"
-    }],
+        "url": "git://github.com/mapbox/tilemill.git"
+    },
     "contributors": [
         "Tom MacWright <tmcw>",
         "Konstantin Kaefer <kkaefer>",


### PR DESCRIPTION
I noticed that this has the wrong git repository URL, which confounds the `npm docs` and `npm bugs` commands.

Also, consider testing against node 0.6.  If it works, you should update the `engines` field to specify this, so that bugs like https://github.com/isaacs/npm/issues/1804 don't happen.

Thanks!
