### PR TITLE
making use of caching of JSV schema instances. 

### DIFF
--- a/models/Base.bones
+++ b/models/Base.bones
@@ -17,12 +17,17 @@ Backbone.Model.prototype.validateAttributes = function(attr) {
         env.setOption('latestJSONSchemaLinksURI', 'http://json-schema.org/links#');
     }
 
-    var properties = ((this.schema.id
-        && env.findSchema(this.schema.id)
-        || env.createSchema(this.schema, undefined, this.schema.id))
-        || env.createSchema(this.schema))
-        .getAttribute('properties');
+    // Determine a Schema ID
+    var schemaId = this.schema.id || this.constructor.title;
 
+    // Load or create a schema instance that is used to validate the attributes.
+    var schemaInstance = findSchema(schemaId) || env.createSchema(this.schema, undefined, schemaId)
+
+    // We will validate against each of the property schemas individually.
+    var properties = schemaInstance.getAttribute('properties');
+
+    // TODO: this could be done more efficiently by breaking on the first error found,
+    //       instead of discarding all the other errors later.
     return _(attr).chain()
         .map(function(v, k) {
             var err;


### PR DESCRIPTION
Rewrote the code for more clarity and added comments. The existing code depends on you to add a model.schema.id field as a caching key to avoid having to rebuild the schema every time validate is called.

the new code uses the this.constructor.title as the cache key if no model.schema.id is found. 
