### PR TITLE
0.4 -> 0.4.x for consistency

### DIFF
--- a/_posts/docs/0201-01-01-upgrade.md
+++ b/_posts/docs/0201-01-01-upgrade.md
@@ -6,7 +6,7 @@ tag: installation
 title: Upgrade notes
 permalink: /docs/upgrade
 ---
-## 0.6
+## 0.6.x
 
 ### Remote network access
 
@@ -34,7 +34,7 @@ On *Ubuntu*, TileMill files are now kept in `~/Documents/MapBox` by default. You
 
 TileMill can now be run as the logged in desktop user on Ubuntu. Look for the TileMill menu item in the Applications menu or Launcher. You may need to adjust file permissions and ownership on your data files to make them readable by TileMill if you decide to move your data from the previous directory (/usr/share/mapbox). You can still run TileMill as a service using the `upstart` command, if so desired.
 
-## 0.4
+## 0.4.x
 
 ### Important note for Ubuntu users
 


### PR DESCRIPTION
Just a light tweak to the upgrade notes to refer to versions as `0.4.x` etc. instead of `0.4` since we use three-part versioning. 
