### PR TITLE
synthesis of schemes/node-v6/skipblank

### DIFF
--- a/commands/export.bones
+++ b/commands/export.bones
@@ -3,8 +3,10 @@ var url = require('url');
 var path = require('path');
 var request = require('request');
 var crypto = require('crypto');
+var util = require('util');
 var Step = require('step');
 var http = require('http');
+var chrono = require('chrono');
 
 command = Bones.Command.extend();
 
@@ -53,6 +55,35 @@ command.options['log'] = {
     'description': 'Write crash logs to destination directory.'
 };
 
+command.options['quiet'] = {
+    'title': 'quiet',
+    'description': 'Suppresses progress output.'
+};
+
+command.options['scheme'] = {
+    'title': 'scheme=[pyramid|file]',
+    'description': 'Enumeration scheme that defines the order in which tiles will be rendered.',
+    'default': 'pyramid'
+};
+
+command.options['job'] = {
+    'title': 'job=[file]',
+    'description': 'Store state in this file. If it exists, that job will be resumed.',
+    'default': false
+};
+
+command.options['metatile'] = {
+    'title': 'metatile=[num]',
+    'description': 'Metatile size.',
+    'default': 2
+};
+
+command.options['concurrency'] = {
+    'title': 'concurrency=[num]',
+    'description': 'Number of exports that can be run concurrently.',
+    'default': 4
+};
+
 command.prototype.initialize = function(plugin, callback) {
     _(this).bindAll('error', 'put', 'complete');
 
@@ -69,7 +100,6 @@ command.prototype.initialize = function(plugin, callback) {
     if (opts.log) {
         process.on('uncaughtException', function(err) {
             fs.writeFileSync(opts.filepath + '.crashlog', err.stack || err.toString());
-            process.exit(1);
         });
     }
 
@@ -80,7 +110,7 @@ command.prototype.initialize = function(plugin, callback) {
 
     // Format.
     if (!opts.format) opts.format = path.extname(opts.filepath).split('.').pop();
-    if (!_(['pdf', 'svg', 'png', 'mbtiles', 'upload', 'sync']).include(opts.format))
+    if (!_(['pdf', 'svg', 'png', 'bigtiles', 'mbtiles', 'upload', 'sync']).include(opts.format))
         return this.error(new Error('Invalid format: ' + opts.format));
 
     // Convert string params into numbers.
@@ -94,6 +124,8 @@ command.prototype.initialize = function(plugin, callback) {
         opts.width = parseInt(opts.width, 10);
     if (!_(opts.height).isUndefined())
         opts.height = parseInt(opts.height, 10);
+    if (!_(opts.metatile).isUndefined())
+        opts.metatile = parseInt(opts.metatile, 10);
 
     // Rename the output filepath using a random hash if file already exists.
     if (path.existsSync(opts.filepath) && !_(['upload','sync']).include(opts.format)) {
@@ -118,15 +150,28 @@ command.prototype.initialize = function(plugin, callback) {
     var cmd = this;
     var model = new models.Project({id:opts.project});
     Step(function() {
+        if (!cmd.opts.quiet) process.stderr.write('Loading project...');
         Bones.utils.fetch({model:model}, this);
     }, function(err) {
-        if (err) throw err;
+        if (err) return cmd.error(err, function() {
+            process.stderr.write(err.stack + '\n');
+            process.exit(1);
+        });
+        if (!cmd.opts.quiet) process.stderr.write(' done.\n');
+        // Set the postgres connection pool size to # of cpus based on
+        // assumption of pool size in tilelive-mapnik.
+        model.get('Layer').each(function(l) {
+            if (l.attributes.Datasource && l.attributes.Datasource.dbname)
+                l.attributes.Datasource.max_size = require('os').cpus().length;
+        });
+        if (!cmd.opts.quiet) process.stderr.write('Localizing project...');
         model.localize(model.toJSON(), this);
     }, function(err) {
         if (err) return cmd.error(err, function() {
             process.exit(1);
         });
 
+        if (!cmd.opts.quiet) process.stderr.write(' done.\n');
         model.mml = _(model.mml).extend({
             name: model.mml.name || model.id,
             version: model.mml.version || '1.0.0',
@@ -183,9 +228,6 @@ command.prototype.remaining = function(progress, started) {
 
 command.prototype.put = function(data, callback) {
     callback = callback || function() {};
-    data.status == 'error' ?
-        console.error(JSON.stringify(data)) :
-        console.log(JSON.stringify(data));
 
     // Allow commands to filter.
     if (this.putFilter) data = this.putFilter(data);
@@ -200,6 +242,42 @@ command.prototype.put = function(data, callback) {
         json: _(data).extend({'bones.token': 'token'})
     }, callback);
 };
+
+
+function formatDuration(duration) {
+    duration = duration / 1000 | 0;
+    var seconds = duration % 60;
+    duration -= seconds;
+    var minutes = (duration % 3600) / 60;
+    duration -= minutes * 60;
+    var hours = (duration % 86400) / 3600;
+    duration -= hours * 3600;
+    var days = duration / 86400;
+
+    return (days > 0 ? days + 'd ' : '') +
+           (hours > 0 || days > 0 ? hours + 'h ' : '') +
+           (minutes > 0 || hours > 0 || days > 0 ? minutes + 'm ' : '') +
+           seconds + 's';
+}
+
+function formatNumber(number, decimals) {
+    var num = parseFloat(number).toFixed(decimals || 0).split('.');
+    for (var i = num[0].length - 3; i > 0; i -= 3) {
+        num[0] = num[0].substring(0, i) + ',' + num[0].substring(i);
+    }
+    return num.join('.');
+}
+
+
+function formatString(string) {
+    var args = arguments;
+    var pos = 1;
+    return string.replace(/%(.)/g, function(_, chr) {
+        if (chr === 's') return args[pos++];
+        if (chr === 'd') return Number(args[pos++]);
+        return chr;
+    });
+}
 
 command.prototype.png =
 command.prototype.svg =
@@ -222,76 +300,123 @@ command.prototype.pdf = function(project, callback) {
     }
 };
 
+command.prototype.bigtiles =
 command.prototype.mbtiles = function (project, callback) {
     var cmd = this;
     var tilelive = require('tilelive');
-    require('mbtiles').registerProtocols(tilelive);
+    require(this.opts.format).registerProtocols(tilelive);
     require('tilelive-mapnik').registerProtocols(tilelive);
 
-    var uri = {
-        protocol: 'mapnik:',
-        slashes: true,
-        xml: project.xml,
-        mml: project.mml,
-        pathname: path.join(this.opts.files, 'project', project.id, project.id + '.xml'),
-        query: { bufferSize: this.opts.bufferSize }
-    };
-    var source;
-    var sink;
+    var opts = this.opts;
 
-    Step(function() {
-        tilelive.load(uri, this);
-    }, function(err, s) {
-        if (err) throw err;
-        source = s;
-        var uri = {protocol:'mbtiles:',pathname:cmd.opts.filepath};
-        tilelive.load(uri, this);
-    }, function(err, s) {
-        if (err) throw err;
-        sink = s;
-        sink.startWriting(this);
-    }, function(err) {
-        if (err) throw err;
-        sink.putInfo(project.mml, this);
-    }, function(err) {
-        if (err) return cmd.error(err, function() {
-            process.exit(1);
-        });
+    // Try to load a job file if one was given and it exists.
+    if (opts.job) {
+        opts.job = path.resolve(opts.job);
+        try {
+            var job = fs.readFileSync(opts.job, 'utf8');
+        } catch(err) {
+            if (err.code !== 'EBADF') throw err;
+        }
+    } else {
+        // Generate a job file based on the output filename.
+        var slug = path.basename(opts.filepath, path.extname(opts.filepath));
+        opts.job = path.join(path.dirname(opts.filepath), slug + '.export');
+    }
 
-        var copy = tilelive.copy({
-            source: source,
-            sink: sink,
+    if (job) {
+        job = JSON.parse(job);
+        if (!cmd.opts.quiet) console.warn('Continuing job ' + opts.job);
+        var scheme = tilelive.Scheme.unserialize(job.scheme);
+        var task = new tilelive.CopyTask(job.from, job.to, scheme, opts.job);
+    } else {
+        if (!cmd.opts.quiet) console.warn('Creating new job ' + opts.job);
+
+        var from = {
+            protocol: 'mapnik:',
+            slashes: true,
+            xml: project.xml,
+            mml: project.mml,
+            pathname: path.join(opts.files, 'project', project.id, project.id + '.xml'),
+            query: { bufferSize: opts.bufferSize, metatile: opts.metatile }
+        };
+
+        var to = {
+            protocol: opts.format + ':',
+            pathname: opts.filepath,
+            query: { batch: 100 }
+        };
+
+        var scheme = tilelive.Scheme.create(opts.scheme, {
             bbox: project.mml.bounds,
-            minZoom: project.mml.minzoom,
-            maxZoom: project.mml.maxzoom,
-            concurrency: 100,
-            tiles: true,
-            grids: !!project.mml.interactivity
+            minzoom: project.mml.minzoom,
+            maxzoom: project.mml.maxzoom,
+            metatile: opts.metatile,
+            concurrency: Math.floor(
+                Math.pow(cmd.opts.metatile, 2) *    // # of tiles in each metatile
+                require('os').cpus().length *       // expect one metatile to occupy each core
+                4 / cmd.opts.concurrency            // overcommit x4 throttle by export concurrency
+            )
+        });
+        var task = new tilelive.CopyTask(from, to, scheme, opts.job);
+    }
+
+
+    var errorfile = path.join(path.dirname(opts.job), path.basename(opts.job) + '-failed');
+    if (!cmd.opts.quiet) console.warn('Writing errors to ' + errorfile);
+
+    fs.open(errorfile, 'a', function(err, fd) {
+        if (err) throw err;
+
+        task.on('error', function(err, tile) {
+            console.warn('\r\033[K' + tile.toString() + ': ' + err.message);
+            fs.write(fd, JSON.stringify(tile) + '\n');
+            report(task.stats.snapshot());
         });
 
-        var done = false;
-        var timeout = setInterval(function progress() {
-            var progress = (copy.copied + copy.failed) / copy.total;
-            cmd.put({
-                status: progress < 1 ? 'processing' : 'complete',
-                progress: progress,
-                remaining: cmd.remaining(progress, copy.started),
-                updated: +new Date(),
+        task.on('progress', report);
+
+        task.on('finished', function() {
+            if (!cmd.opts.quiet) console.warn('\nfinished');
+        });
+
+        task.start(function(err) {
+            if (err) throw err;
+            task.sink.putInfo(project.mml, function(err) {
+                if (err) throw err;
             });
-        }, 5000);
-
-        copy.on('warning', function(err) {
-            console.log(err);
-        });
-        copy.on('finished', function() {
-            clearInterval(timeout);
-            callback();
-        });
-        copy.on('error', function(err) {
-            clearInterval(timeout);
-            callback(err);
         });
     });
+
+    function report(stats) {
+        var progress = stats.processed / stats.total;
+        var remaining = cmd.remaining(progress, task.started);
+        cmd.put({
+            status: progress < 1 ? 'processing' : 'complete',
+            progress: progress,
+            remaining: remaining,
+            updated: +new Date(),
+            rate: stats.speed
+        });
+
+        if (!cmd.opts.quiet) {
+            util.print(formatString('\r\033[K[%s] %s%% (%s/%s) | %s/s | %s left | uniq: %s (%s%%) | dupe: %s (%s%%) | skip: %s (%s%%) | fail: %s (%s%%)',
+                formatDuration(stats.date - task.started),
+                ((progress || 0) * 100).toFixed(4),
+                formatNumber(stats.processed),
+                formatNumber(stats.total),
+                formatNumber(stats.speed),
+                formatDuration(remaining),
+                formatNumber(stats.unique),
+                (((stats.unique / stats.processed) || 0) * 100).toFixed(2),
+                formatNumber(stats.duplicate),
+                (((stats.duplicate / stats.processed) || 0) * 100).toFixed(2),
+                formatNumber(stats.skipped),
+                (((stats.skipped / stats.processed) || 0) * 100).toFixed(2),
+                formatNumber(stats.failed),
+                (((stats.failed / stats.processed) || 0) * 100).toFixed(2)
+            ));
+        }
+    }
 };
 
 command.prototype.upload = function (callback) {

--- a/package.json
+++ b/package.json
@@ -22,31 +22,33 @@
     "licenses": [{ "type": "BSD" }],
     "dependencies": {
         "backbone-dirty": "1.1.x",
-        "bones": "https://github.com/developmentseed/bones/tarball/1.3",
+        "bones": "~1.3.24",
         "chrono": "~1.0.1",
         "JSV": "3.5.x",
-        "mbtiles": "~0.1.2",
+        "mbtiles": "~0.2.0",
+        "bigtiles": "~0.1.0",
         "sax": "0.1.x",
-        "request": "1.9.x",
-        "step": "0.0.x",
-        "tilelive": "~4.0.3",
-        "mapnik": "https://github.com/mapnik/node-mapnik/tarball/node_v4",
-        "millstone": "~0.3.0",
+        "request": "~2.9.153",
+        "step": "~0.0.5",
+        "tilelive": "~4.2.0",
+        "mapnik": "~0.6.7",
+        "millstone": "~0.4.0",
         "sphericalmercator": "~1.0.1",
-        "tilelive-mapnik": "~0.2.0",
-        "underscore": "1.1.x",
-        "carto": "~0.4.3",
+        "eio": "https://github.com/developmentseed/node-eio/tarball/master",
+        "tilelive-mapnik": "~0.3.0",
+        "underscore": "~1.3.1",
+        "carto": "~0.4.5",
         "wax": "5.0.0-alpha2",
         "node-markdown": "0.1.0",
-        "sqlite3": "~2.0.16",
+        "sqlite3": "~2.1.1",
         "passport": "0.1.x",
         "passport-oauth": "0.1.x",
         "modestmaps": "1.0.0-alpha",
-        "npm": "1.0.x",
+        "npm": "1.1.x",
         "semver": "1.0.x",
-        "optimist": "0.1.x",
-        "topcube": "https://github.com/creationix/topcube/tarball/master",
-        "mkdirp": "~0.2.1"
+        "optimist": "~0.3.1",
+        "topcube": "https://github.com/creationix/topcube/tarball/v0.1.2",
+        "mkdirp": "~0.3.0"
     },
     "devDependencies": {
         "jshint": "0.2.x"
@@ -59,5 +61,5 @@
     "bin": {
         "tilemill": "./index.js"
     },
-    "engines": { "node": "0.4.x" }
+    "engines": { "node": "0.6.x" }
 }


### PR DESCRIPTION
This moves master TileMill to >= node 0.6.x.

Only known remaining issues are minor and can be dealt with after merge. They are:

1) node-eio needs published (npmjs.org was not cooperating).

2) test failure:

```
   uncaught undefined: Error: connect ECONNREFUSED
    at errnoException (net.js:646:11)
    at Object.afterConnect [as oncomplete] (net.js:637:18)

   config.test.js config: Error: Response not completed: config. 
    at Function.response (/usr/local/lib/node_modules/expresso/bin/expresso:400:17)
    at Function.<anonymous> (/Users/dane/projects/tilemill/test/config.test.js:29:12)
```

This may be a result of https://github.com/joyent/node/issues/2334. We should likely just upgrade to use mocha.

3) duplicated underscore/generic pool versions - missed a few before tagging carto,bones, millstone. 
