### PR TITLE
Slightly more detail in export --bbox option

### DIFF
--- a/commands/export.bones
+++ b/commands/export.bones
@@ -22,7 +22,7 @@ command.options['format'] = {
 };
 
 command.options['bbox'] = {
-    'title': 'bbox=[bbox]',
+    'title': 'bbox=[xmin,ymin,xmax,ymax]',
     'description': 'Comma separated coordinates of bounding box to export.'
 };
 


### PR DESCRIPTION
I've added what I believe to be the proper order of bbox components to the help text. Personally, I had to look it up elsewhere before I knew the right order to use.
