### PR TITLE
Adding a table id to better access it

### DIFF
--- a/templates/Datasource._
+++ b/templates/Datasource._
@@ -14,7 +14,7 @@ obj.escape = function(string) {
 </a>
 </div>
 <div class='features fill scrolling'>
-<table>
+<table id='features'>
   <thead>
     <tr>
       <% _(fields).each(function (field, name) { %>


### PR DESCRIPTION
I'm writing a tilemill plugin and wanted a better way to access the table element in datasource._ Any reason not to include this markup change?

cc @springmeyer 
