### PR TITLE
Ensure that automatically generated layer names and ids don't cause conf...

### DIFF
--- a/views/Layer.bones
+++ b/views/Layer.bones
@@ -161,7 +161,8 @@ view.prototype.placeholderUpdate = function(ev) {
 // untenable for queries.
 view.prototype.autoname = function(source) {
     var sep = window.abilities.platform === 'win32' ? '\\' : '/';
-    return _(source.split(sep)).chain()
+
+    var cleanname = _(source.split(sep)).chain()
         .map(function(chunk) { return chunk.split('\\'); })
         .flatten()
         .last()
@@ -172,6 +173,24 @@ view.prototype.autoname = function(source) {
         .replace('selectfrom','')
         .replace('select','')
         .substr(0,20);
+
+    if (!cleanname) {
+        return "";
+    }
+
+    var attr = Bones.utils.form(this.model);
+
+    attr.name =
+    attr.id = cleanname;
+
+    var count = 2;
+    while (this.model.validate(attr)) {
+        attr.name =
+        attr.id = cleanname + count;
+        count++;
+    }
+
+    return attr.id;
 };
 
 view.prototype.browse = function(ev) {


### PR DESCRIPTION
...licts

This is in response to Issue #1744, the new behaviour is to append a number, starting with 2, to the auto-generated name if a layer with that name already exists.
