### PR TITLE
[ui] Fix "*" link not working in carto reference (see mapbox/tilemill#1693)

### DIFF
--- a/views/App.bones
+++ b/views/App.bones
@@ -167,13 +167,17 @@ view.prototype.toggler = function(ev) {
     var link = $(ev.currentTarget);
     var parent = link.parents('.toggler');
     var target = link.attr('href').split('#').pop();
+    var targetSelector = '.' + target;
+    // mapnik-reference comes with a "*" simbolizer which ends in
+    // a "section-*" class name, but "*" is a metacharacter for jQuery
+    targetSelector = targetSelector.replace('*', '\\*');
     if (link.hasClass('disabled')) return false;
 
     $('a', parent).removeClass('active');
-    this.$('.' + target).siblings('.active').removeClass('active');
+    this.$(targetSelector).siblings('.active').removeClass('active');
 
     link.addClass('active');
-    this.$('.' + target).addClass('active');
+    this.$(targetSelector).addClass('active');
     return false;
 };
 


### PR DESCRIPTION
I run into this [little annoying bug](https://github.com/mapbox/tilemill/issues/1693) today, so here is a quick patch.

The ["*" mapnik-reference symbolizer](https://github.com/mapnik/mapnik-reference/blob/master/latest/reference.json#L145) causes a `section-*` className to be created and then queried with jQuery selector, while `*` is a [metacharacter](http://api.jquery.com/category/selectors/) for jQuery.

I'm not aware of some escape method in jQuery itself, hence some ad hoc solution seemed needed.
Thus, I've seen four solutions:
- change value in mapnik-reference
- fix input while importing it from mapnik-reference (say "*" become "all")
- do a proper "selectorEscape" that escape every metacharacter and use it where needed (in `view.toggler`, almost)
- just escape `*` where needed (in `view.toggler`)

Having no overview of tilemill internal, I thought the last solution was enough, but I may be wrong. ;)

Thanks!

Yohan
