### PR TITLE
Redesigned Projects View

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -445,7 +445,7 @@ small { font-size:11px; }
 /**
  * Projects
  */
-ul.projects { margin:0px -5px; }
+ul.projects { margin: 10px 5px 0px 5px; }
 
 .projects span.actions {
   display:block;
@@ -486,10 +486,20 @@ ul.projects { margin:0px -5px; }
   opacity:0.5;
   position:absolute;
   right:9px;
-  top:19px;
+  top:9px;
   }
 
 .projects a.thumb .icon:hover { opacity:1; }
+
+.projects .description {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  -o-text-overflow: ellipsis;
+  white-space: nowrap;
+  width: 100%;
+}
+
+a#newproject {margin-left: 0px;}
 
 /**
  * Project

--- a/templates/Projects._
+++ b/templates/Projects._
@@ -1,21 +1,25 @@
-<ul class='projects grid'>
-  <li>
-  <span class='sunken actions'>
-    <a class='button large popup' href='#add'>
-      <span class='icon plus reverse labeled'></span>
-      New project
-    </a>
-  </span>
-  </li>
-  <% _(models).each(function(model) { %>
-  <li>
-  <a class='raised thumb' href='#/project/<%= model.id %>'>
-    <span class='thumb'></span>
-    <span class='thumb' style='background:url(<%=model.thumb()%>) 50% 50% no-repeat; background-size:cover'></span>
-    <%= model.get('name') || model.get('id') %><br/>
-    <small class='description'>Updated <%= new Date(model.get('_updated')).format('D M j g:ia') %></small>
-    <span id='<%= model.id %>' class='icon delete'>Delete</span>
-  </a>
-  </li>
-  <% }); %>
+<ul class="form sunken">
+    <li class='text'>
+      <h2>Projects</h2>
+    </li>
+    <ul class='projects grid clearfix'>
+    <% _(models).each(function(model) { %>
+    <li class="project">
+      <a class='raised thumb' href='#/project/<%= model.id %>'>
+        <span class='thumb'></span>
+        <span class='thumb' style='background:url(<%=model.thumb()%>) 50% 50% no-repeat; background-size:cover'></span>
+        <%= model.get('name') || model.get('id') %>
+        <span id='<%= model.id %>' class='icon delete'>Delete</span>
+        <!-- Substituted last updated with Project description -->
+        <!-- <small class='description'>Updated <%= new Date(model.get('_updated')).format('D M j g:ia') %></small>-->
+         <small class='description'><%= model.get('description')%></small>      
+      </a>
+    </li>
+    <% }); %>
+  </ul>
 </ul>
+
+<a class='button large popup' id="newproject" href='#add'>
+    <span class='icon plus reverse labeled'></span>
+    New project
+</a>


### PR DESCRIPTION
A redesign of the Projects view more in line with the design of other sections of the app, such as Plugins.
Also seemed to exist an issue displaying the last time a project was updated, so I replaced it with the project's description — trimmed via CSS to adapt to the application's window size.

Original version:
![tilemill_original](https://f.cloud.github.com/assets/1041/75170/7f250c16-60b8-11e2-97b7-c4023bc164cb.png)

Redesigned version:
![tilemill_redesign](https://f.cloud.github.com/assets/1041/75172/8ef175f8-60b8-11e2-9d13-f613e2d2ae42.png)
