### PR TITLE
Force the project name to a string or path.resolve will ignore it later.

### DIFF
--- a/commands/export.bones
+++ b/commands/export.bones
@@ -104,7 +104,7 @@ command.prototype.initialize = function(plugin, callback) {
     if (process.env.tilemillConfig)
         _(opts).extend(JSON.parse(process.env.tilemillConfig));
     opts.files = path.resolve(opts.files);
-    opts.project = plugin.argv._[1];
+    opts.project = plugin.argv._[1].toString();
     var export_filename = plugin.argv._[2];
     if (!export_filename) return plugin.help();
     opts.filepath = path.resolve(export_filename.replace(/^~/,process.env.HOME));


### PR DESCRIPTION
Without this exports with only digits in their name cannot be exported as path.resolve ignores non-string arguments are ignored [http://nodejs.org/api/path.html#path_path_resolve_from_to]

This just forces the argument to a string when it is read from the command line.
Without this the error occurs at models/Project.server.bones:164.
