### PR TITLE
Optional project description

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -489,7 +489,19 @@ ul.projects { margin:0px -5px; }
   top:19px;
   }
 
+.projects a.thumb .icon.info {
+  top:30px;
+}
+
 .projects a.thumb .icon:hover { opacity:1; }
+
+.projects a.thumb small.description {
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  margin-right: 20px;
+  height: 40px;
+}
 
 /**
  * Project

--- a/templates/Projects._
+++ b/templates/Projects._
@@ -10,11 +10,16 @@
   <% _(models).each(function(model) { %>
   <li>
   <a class='raised thumb' href='#/project/<%= model.id %>'>
-    <span class='thumb'></span>
-    <span class='thumb' style='background:url(<%=model.thumb()%>) 50% 50% no-repeat; background-size:cover'></span>
-    <%= model.get('name') || model.get('id') %><br/>
-    <small class='description'>Updated <%= new Date(model.get('_updated')).format('D M j g:ia') %></small>
-    <span id='<%= model.id %>' class='icon delete'>Delete</span>
+      <span class='thumb' style='background:url(<%=model.thumb()%>) 50% 50% no-repeat; background-size:cover'></span>
+    <p class="name"><%= model.get('name') || model.get('id') %></p>
+      <small class='last_update'>Updated <%= new Date(model.get('_updated')).format('D M j g:ia') %></small>
+    <% if (model.get('description')) { %>
+      <small class='description' style="display: none;"><%= model.get('description')%></small>
+    <% }; %>      
+      <span id='<%= model.id %>' class='icon delete'>Delete</span>
+    <% if (model.get('description')) { %>
+      <span id='<%= model.id %>' class='icon info'>Description</span>
+    <% }; %>
   </a>
   </li>
   <% }); %>

--- a/views/Projects.bones
+++ b/views/Projects.bones
@@ -1,10 +1,12 @@
 view = Backbone.View.extend({
     events: {
         'click a[href=#add]': 'add',
-        'click .delete': 'del'
+        'click .delete': 'del',
+        'mouseover .info': 'description',
+        'mouseleave .info': 'info'
     },
     initialize: function() {
-        _(this).bindAll('render', 'add', 'del');
+        _(this).bindAll('render', 'add', 'del', 'description', 'info');
         this.collection.bind('add', this.render);
         this.collection.bind('remove', this.render);
         this.render();
@@ -44,5 +46,16 @@ view = Backbone.View.extend({
             affirmative: 'Delete'
         });
         return false;
+    },
+    description: function(ev){
+        $(ev.currentTarget).siblings('.name').hide();
+        $(ev.currentTarget).siblings('.last_update').hide();
+        $(ev.currentTarget).siblings('.description').show();
+
+    },
+    info: function(ev){
+        $(ev.currentTarget).siblings('.description').hide();
+        $(ev.currentTarget).siblings('.name').show();
+        $(ev.currentTarget).siblings('.last_update').show();
     }
 });


### PR DESCRIPTION
Added an optional information icon to projects that have a description.
On mouseover it will replace the project title and the update date with the description.
On mouseleave returns to the previous state.

![Screen Shot 2013-04-10 at 5 12 31 PM](https://f.cloud.github.com/assets/1041/363171/96be5484-a1fb-11e2-8b48-4810001e1046.png)

Finally found the time to work on this after a few months.

Issue: for project descriptions longer than two lines it will cut the text. CSS ellipsis will only work on one line text. If there is interest in integrating this solution on the project I will research a solution without requiring further integration of jQuery plugins (which was the easiest solution I found).
