### PR TITLE
revise string matching for node v0.10.x

### DIFF
--- a/platforms/osx/TileMillAppDelegate.m
+++ b/platforms/osx/TileMillAppDelegate.m
@@ -325,8 +325,8 @@
 {
     [self writeToLog:output];
     
-    if ([[NSPredicate predicateWithFormat:@"SELF contains 'throw e; // process'"] evaluateWithObject:output] ||
-        [[NSPredicate predicateWithFormat:@"SELF contains 'Error(\"Cannot find module'"] evaluateWithObject:output]
+    if ([[NSPredicate predicateWithFormat:@"SELF contains 'Error:'"] evaluateWithObject:output] ||
+        [![NSPredicate predicateWithFormat:@"SELF contains 'Client Error"] evaluateWithObject:output]
         )
         [self presentFatalError];
 


### PR DESCRIPTION
I noticed the windows wrapper is no longer catching errors correctly (fatal errors are silent) with node v0.10.x because `throw e;` is now `throw err;` (https://github.com/mapbox/tilemill-win-launcher/blob/b503a2591d2bb4e4f9c90b3dc781861ce02ed784/tilemill.cc#L86). This pull fixes to just look for `Error:` but avoids matching bones `Client Error`:

Needs testing on OS X (ideally by @incanus) before merging.
