### PR TITLE
Improve automatic layer names from SQL queries.

### DIFF
--- a/views/Layer.bones
+++ b/views/Layer.bones
@@ -178,6 +178,7 @@ view.prototype.placeholderUpdate = function(ev) {
 
 // Currently handles URLs and brute forces SQL queries into something usable.
 // @TODO smarter handling for this (different handling depending on datasource type)
+// @TODO handle /* SQL comments */ - currently they break everything and give a blank string.
 view.prototype.autoname = function(source) {
     var sep = window.abilities.platform === 'win32' ? '\\' : '/';
 


### PR DESCRIPTION
I added a few more rules to strip out other SQL keywords. Probably the smarter thing to do would be to have completely separate handling for SQL layers, and to look specifically for table and value names.

I added a rule to strip out osm2pgsql table names, because it seemed to work better in my testing. Instead of "planetosmlinehighwaypa" type names, you get "highwaypath". I would imagine that most people using osm data are going to have quite a few layers derived from the same few tables, and this way you get almost reasonable layer names by default.
