### PR TITLE
Documentation: clarify where the shapefiles need to go

### DIFF
--- a/_posts/docs/guides/0203-01-01-osm-bright-mac-quickstart.md
+++ b/_posts/docs/guides/0203-01-01-osm-bright-mac-quickstart.md
@@ -121,8 +121,11 @@ Download a zip archive of the latest version of OSM Bright from <https://github.
 
 OSM Bright depends on two large shapefiles. You will need to download and extract them before continuing.
 
-Download them to the shp directory in the osm-bright folder. You can do this with wget like:
+Download them to the shp directory in the mapbox-osm-bright-* folder. You can do this with wget like:
 
+    cd ~/Downloads/mapbox-osm-bright-*
+    mkdir shp
+    cd shp
     wget http://data.openstreetmapdata.com/simplified-land-polygons-complete-3857.zip
     wget http://data.openstreetmapdata.com/land-polygons-split-3857.zip
 


### PR DESCRIPTION
Hi,

Here's a small doc update on the OSX guide to clarify where the shape files should go.

The documentation states that it should be put in the shp directory in the osm-bright folder but what is meant is the mapbox-osm-bright-* folder (ie. the root project folder). Also the OSM Bright repo does not contain a shp folder so we update the doc to reflect this.