### PR TITLE
Fix bugs based on versions and make instructions clearer

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,16 @@ To install from source just do:
 
 Then to start TileMill do:
 
-    ./index.js # and then view http://localhost:20009 in your web browser
+As a Desktop application:
+
+    ./index.js 
+
+To run the **web version** pass `server=true`: 
+	
+    ./index.js --server=true
+
+and then go to `localhost:20009` in your web browser
+
 
 For more extended details follow:
 

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "passport": "0.2.x",
     "passport-oauth": "1.0.x",
     "progress-stream": "^1.2.0",
-    "request": "2.x",
+    "request": "2.81.0",
     "rimraf": "^2.5.2",
     "sax": "0.6.x",
     "semver": "~4.1.0",


### PR DESCRIPTION
Since `request` updated its dependencies they're now using ES6 features that are not compatible with tilemill's engines node 0.8.x or 0.10.x. This PR fixes the `request` dependency to `2.81.0` to avoid this conflict. 

I also updated the README.md to reflect that the default application that will run is the Desktop app, and how to run the web server version.