### PR TITLE
Fix security vulnerabilities from Github

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1334,9 +1334,9 @@
             "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
         },
         "jquery": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/jquery/-/jquery-2.1.0.tgz",
-            "integrity": "sha1-HJqMlx0rU9rhDXLhbLtaHfFqSs4="
+            "version": "3.3.1",
+            "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.3.1.tgz",
+            "integrity": "sha512-Ubldcmxp5np52/ENotGxlLe6aGMvmF4R8S6tZjsP6Knsaxd/xp3Zrh50cG93lR6nPXyUFwzN3ZSOQI0wRJNdGg=="
         },
         "js-yaml": {
             "version": "3.8.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,22 @@
             "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
             "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
         },
+        "accepts": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.0.3.tgz",
+            "integrity": "sha1-krHbDU89tHsFMN9uFa6X21FNwvg=",
+            "requires": {
+                "mime": "~1.2.11",
+                "negotiator": "0.4.6"
+            },
+            "dependencies": {
+                "mime": {
+                    "version": "1.2.11",
+                    "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz",
+                    "integrity": "sha1-WCA+7Ybjpe8XrtK32evUfwpg3RA="
+                }
+            }
+        },
         "acorn": {
             "version": "0.11.0",
             "resolved": "https://registry.npmjs.org/acorn/-/acorn-0.11.0.tgz",
@@ -162,12 +178,53 @@
             "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
             "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
         },
+        "base64-url": {
+            "version": "1.3.3",
+            "resolved": "https://registry.npmjs.org/base64-url/-/base64-url-1.3.3.tgz",
+            "integrity": "sha1-+LbFN/CaT8WMmcuG4LDpxhRhog8="
+        },
+        "basic-auth-connect": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/basic-auth-connect/-/basic-auth-connect-1.0.0.tgz",
+            "integrity": "sha1-/bC0OWLKe0BFanwrtI/hc9otISI="
+        },
+        "batch": {
+            "version": "0.5.1",
+            "resolved": "https://registry.npmjs.org/batch/-/batch-0.5.1.tgz",
+            "integrity": "sha1-NqS6tZTAUP17UHvKDbMMLZKvT/I="
+        },
         "bcrypt-pbkdf": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
             "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
             "requires": {
                 "tweetnacl": "^0.14.3"
+            }
+        },
+        "body-parser": {
+            "version": "1.4.3",
+            "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.4.3.tgz",
+            "integrity": "sha1-RyeVLP9K8Hc+76SyJsL0Ei9eI00=",
+            "requires": {
+                "bytes": "1.0.0",
+                "depd": "0.3.0",
+                "iconv-lite": "0.4.3",
+                "media-typer": "0.2.0",
+                "qs": "0.6.6",
+                "raw-body": "1.2.2",
+                "type-is": "1.3.1"
+            },
+            "dependencies": {
+                "iconv-lite": {
+                    "version": "0.4.3",
+                    "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.3.tgz",
+                    "integrity": "sha1-nniHeTt2nMaV6yLSVGpP0tebeh4="
+                },
+                "qs": {
+                    "version": "0.6.6",
+                    "resolved": "https://registry.npmjs.org/qs/-/qs-0.6.6.tgz",
+                    "integrity": "sha1-bgFQmP9RlouKPIGQAdXyyJvEsQc="
+                }
             }
         },
         "bones": {
@@ -182,6 +239,17 @@
                 "underscore": "~1.1.7"
             },
             "dependencies": {
+                "express": {
+                    "version": "2.5.11",
+                    "resolved": "https://registry.npmjs.org/express/-/express-2.5.11.tgz",
+                    "integrity": "sha1-TOjqHzY15p5J8Ou0l7aksKUc5vA=",
+                    "requires": {
+                        "connect": "1.x",
+                        "mime": "1.2.4",
+                        "mkdirp": "0.3.0",
+                        "qs": "0.4.x"
+                    }
+                },
                 "jsdom": {
                     "version": "4.0.0",
                     "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-4.0.0.tgz",
@@ -200,6 +268,11 @@
                         "xml-name-validator": "^1.0.0",
                         "xmlhttprequest": ">= 1.6.0 < 2.0.0"
                     }
+                },
+                "mkdirp": {
+                    "version": "0.3.0",
+                    "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz",
+                    "integrity": "sha1-G79asbqCevI1dRQ0kEJkVfSB/h4="
                 },
                 "underscore": {
                     "version": "1.1.7",
@@ -241,10 +314,20 @@
             "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
             "dev": true
         },
+        "buffer-crc32": {
+            "version": "0.2.3",
+            "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.3.tgz",
+            "integrity": "sha1-u1RRnpXRB8vSQA520MqxRnM22SE="
+        },
         "builtin-modules": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
             "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8="
+        },
+        "bytes": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/bytes/-/bytes-1.0.0.tgz",
+            "integrity": "sha1-NWnt6Lo0MV+rmcPpLLBMciDeH6g="
         },
         "camelcase": {
             "version": "4.1.0",
@@ -344,6 +427,23 @@
             "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
             "dev": true
         },
+        "compressible": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/compressible/-/compressible-1.1.0.tgz",
+            "integrity": "sha1-Ek2Ke7oYoFpBCi8lutQTsblK/2c="
+        },
+        "compression": {
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/compression/-/compression-1.0.7.tgz",
+            "integrity": "sha1-/Ev/Jh3043oTAAby2yqZo0iW9Vo=",
+            "requires": {
+                "accepts": "1.0.3",
+                "bytes": "1.0.0",
+                "compressible": "1.1.0",
+                "on-headers": "0.0.0",
+                "vary": "0.1.0"
+            }
+        },
         "concat-map": {
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -359,10 +459,53 @@
                 "qs": ">= 0.4.0"
             }
         },
+        "connect-timeout": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/connect-timeout/-/connect-timeout-1.1.1.tgz",
+            "integrity": "sha1-bH4xyY8Kxo620TBfZ/IfWm6Q/QQ=",
+            "requires": {
+                "debug": "1.0.2",
+                "on-headers": "0.0.0"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-1.0.2.tgz",
+                    "integrity": "sha1-OElZHBDM5khHbDx8Li40FttZY8Q=",
+                    "requires": {
+                        "ms": "0.6.2"
+                    }
+                },
+                "ms": {
+                    "version": "0.6.2",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz",
+                    "integrity": "sha1-2JwhJMb9wTU9Zai3e/GqxLGTcIw="
+                }
+            }
+        },
         "console-control-strings": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
             "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
+        },
+        "cookie": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.1.2.tgz",
+            "integrity": "sha1-cv7D0k5Io0Mgc9kMEmQgBQYQBLE="
+        },
+        "cookie-parser": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.3.1.tgz",
+            "integrity": "sha1-ML/CkGoESJ1ZvLnjL5DbCOBLtR4=",
+            "requires": {
+                "cookie": "0.1.2",
+                "cookie-signature": "1.0.3"
+            }
+        },
+        "cookie-signature": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.3.tgz",
+            "integrity": "sha1-kc2ZfMUftkFZVzjGnNoCAyj1D/k="
         },
         "core-util-is": {
             "version": "1.0.2",
@@ -387,6 +530,17 @@
                 "boom": "2.x.x"
             }
         },
+        "csrf-tokens": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/csrf-tokens/-/csrf-tokens-2.0.0.tgz",
+            "integrity": "sha1-yCEAP7i2rRe8l31v0ahL7cPtYZs=",
+            "requires": {
+                "base64-url": "1",
+                "rndm": "1",
+                "scmp": "~0.0.3",
+                "uid-safe": "1"
+            }
+        },
         "cssom": {
             "version": "0.3.4",
             "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.4.tgz",
@@ -398,6 +552,14 @@
             "integrity": "sha1-VBCXI0yyUTyDzu06zdwn/yeYfVQ=",
             "requires": {
                 "cssom": "0.3.x"
+            }
+        },
+        "csurf": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/csurf/-/csurf-1.2.2.tgz",
+            "integrity": "sha1-Lqny0/LWex4iUykOZ2tiGV3Ld1Y=",
+            "requires": {
+                "csrf-tokens": "~2.0.0"
             }
         },
         "dashdash": {
@@ -448,6 +610,11 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
             "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
+        },
+        "depd": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/depd/-/depd-0.3.0.tgz",
+            "integrity": "sha1-Ecm8KOQlMl+9iziUC+/2n6UyaIM="
         },
         "detect-libc": {
             "version": "1.0.3",
@@ -523,6 +690,11 @@
                 "safer-buffer": "^2.1.0"
             }
         },
+        "ee-first": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.0.3.tgz",
+            "integrity": "sha1-bJjECJq+y1p7hcGsRJqmA9Oz2r4="
+        },
         "entities": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
@@ -535,6 +707,20 @@
             "requires": {
                 "is-arrayish": "^0.2.1"
             }
+        },
+        "errorhandler": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/errorhandler/-/errorhandler-1.1.0.tgz",
+            "integrity": "sha1-JzsOuFCtED6abWOpmB2G8bmhIC4=",
+            "requires": {
+                "accepts": "1.0.3",
+                "escape-html": "1.0.1"
+            }
+        },
+        "escape-html": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.1.tgz",
+            "integrity": "sha1-GBoobq05ejmpKFfPsdQwUuNWv/A="
         },
         "escape-string-regexp": {
             "version": "1.0.5",
@@ -584,20 +770,119 @@
             }
         },
         "express": {
-            "version": "2.5.11",
-            "resolved": "https://registry.npmjs.org/express/-/express-2.5.11.tgz",
-            "integrity": "sha1-TOjqHzY15p5J8Ou0l7aksKUc5vA=",
+            "version": "3.11.0",
+            "resolved": "https://registry.npmjs.org/express/-/express-3.11.0.tgz",
+            "integrity": "sha1-8cjhyZGkRN164zG/t/GkVX/P0u4=",
             "requires": {
-                "connect": "1.x",
-                "mime": "1.2.4",
-                "mkdirp": "0.3.0",
-                "qs": "0.4.x"
+                "buffer-crc32": "0.2.3",
+                "commander": "1.3.2",
+                "connect": "2.20.2",
+                "cookie": "0.1.2",
+                "cookie-signature": "1.0.3",
+                "debug": "1.0.2",
+                "depd": "0.3.0",
+                "escape-html": "1.0.1",
+                "fresh": "0.2.2",
+                "merge-descriptors": "0.0.2",
+                "methods": "1.0.1",
+                "mkdirp": "0.5.0",
+                "parseurl": "1.0.1",
+                "proxy-addr": "1.0.1",
+                "range-parser": "1.0.0",
+                "send": "0.4.3",
+                "vary": "0.1.0"
             },
             "dependencies": {
-                "mkdirp": {
-                    "version": "0.3.0",
-                    "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz",
-                    "integrity": "sha1-G79asbqCevI1dRQ0kEJkVfSB/h4="
+                "commander": {
+                    "version": "1.3.2",
+                    "resolved": "https://registry.npmjs.org/commander/-/commander-1.3.2.tgz",
+                    "integrity": "sha1-io8w7GcKb91kr1LxkUuQfXnq1bU=",
+                    "requires": {
+                        "keypress": "0.1.x"
+                    }
+                },
+                "connect": {
+                    "version": "2.20.2",
+                    "resolved": "https://registry.npmjs.org/connect/-/connect-2.20.2.tgz",
+                    "integrity": "sha1-RLxkM0x668IZfFLGh0cUAC0Jd74=",
+                    "requires": {
+                        "basic-auth-connect": "1.0.0",
+                        "body-parser": "1.4.3",
+                        "bytes": "1.0.0",
+                        "compression": "1.0.7",
+                        "connect-timeout": "1.1.1",
+                        "cookie": "0.1.2",
+                        "cookie-parser": "1.3.1",
+                        "cookie-signature": "1.0.3",
+                        "csurf": "1.2.2",
+                        "debug": "1.0.2",
+                        "depd": "0.3.0",
+                        "errorhandler": "1.1.0",
+                        "express-session": "1.4.0",
+                        "finalhandler": "0.0.2",
+                        "fresh": "0.2.2",
+                        "media-typer": "0.2.0",
+                        "method-override": "2.0.2",
+                        "morgan": "1.1.1",
+                        "multiparty": "3.2.9",
+                        "on-headers": "0.0.0",
+                        "parseurl": "1.0.1",
+                        "pause": "0.0.1",
+                        "qs": "0.6.6",
+                        "response-time": "2.0.0",
+                        "serve-favicon": "2.0.1",
+                        "serve-index": "1.1.2",
+                        "serve-static": "1.2.3",
+                        "type-is": "1.3.1",
+                        "vhost": "2.0.0"
+                    }
+                },
+                "debug": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-1.0.2.tgz",
+                    "integrity": "sha1-OElZHBDM5khHbDx8Li40FttZY8Q=",
+                    "requires": {
+                        "ms": "0.6.2"
+                    }
+                },
+                "ms": {
+                    "version": "0.6.2",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz",
+                    "integrity": "sha1-2JwhJMb9wTU9Zai3e/GqxLGTcIw="
+                },
+                "qs": {
+                    "version": "0.6.6",
+                    "resolved": "https://registry.npmjs.org/qs/-/qs-0.6.6.tgz",
+                    "integrity": "sha1-bgFQmP9RlouKPIGQAdXyyJvEsQc="
+                }
+            }
+        },
+        "express-session": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/express-session/-/express-session-1.4.0.tgz",
+            "integrity": "sha1-kL+Kk5ocjcAS5KEeTC/DYp98+JQ=",
+            "requires": {
+                "buffer-crc32": "0.2.3",
+                "cookie": "0.1.2",
+                "cookie-signature": "1.0.3",
+                "debug": "1.0.2",
+                "on-headers": "0.0.0",
+                "rand-token": "0.2.1",
+                "utils-merge": "1.0.0"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-1.0.2.tgz",
+                    "integrity": "sha1-OElZHBDM5khHbDx8Li40FttZY8Q=",
+                    "requires": {
+                        "ms": "0.6.2"
+                    }
+                },
+                "ms": {
+                    "version": "0.6.2",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz",
+                    "integrity": "sha1-2JwhJMb9wTU9Zai3e/GqxLGTcIw="
                 }
             }
         },
@@ -616,12 +901,44 @@
             "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
             "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
         },
+        "finalhandler": {
+            "version": "0.0.2",
+            "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.0.2.tgz",
+            "integrity": "sha1-BgPYde6H1WeiZmkoFcyK1E/M7to=",
+            "requires": {
+                "debug": "1.0.2",
+                "escape-html": "1.0.1"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-1.0.2.tgz",
+                    "integrity": "sha1-OElZHBDM5khHbDx8Li40FttZY8Q=",
+                    "requires": {
+                        "ms": "0.6.2"
+                    }
+                },
+                "ms": {
+                    "version": "0.6.2",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz",
+                    "integrity": "sha1-2JwhJMb9wTU9Zai3e/GqxLGTcIw="
+                }
+            }
+        },
         "find-up": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
             "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
             "requires": {
                 "locate-path": "^2.0.0"
+            }
+        },
+        "finished": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/finished/-/finished-1.2.2.tgz",
+            "integrity": "sha1-QWCOr639ZWg7RqEiC8Sx7D2u3Ng=",
+            "requires": {
+                "ee-first": "1.0.3"
             }
         },
         "forever-agent": {
@@ -643,6 +960,11 @@
             "version": "1.0.16",
             "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.0.16.tgz",
             "integrity": "sha1-SRbP38TL7QILJXpqlQWpqzjCzQ4="
+        },
+        "fresh": {
+            "version": "0.2.2",
+            "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.2.2.tgz",
+            "integrity": "sha1-lzHc9WeMf660T7kDxPct9VGH+nc="
         },
         "fs-minipass": {
             "version": "1.2.5",
@@ -1287,6 +1609,11 @@
             "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
             "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
         },
+        "ipaddr.js": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-0.1.2.tgz",
+            "integrity": "sha1-ah/T2FT1ACllw017vNm0qNSwRn4="
+        },
         "is-arrayish": {
             "version": "0.2.1",
             "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
@@ -1436,6 +1763,11 @@
                     "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
                 }
             }
+        },
+        "keypress": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/keypress/-/keypress-0.1.0.tgz",
+            "integrity": "sha1-SjGI1CkbZrT2XtuZ+AaqmuKTWSo="
         },
         "lcid": {
             "version": "1.0.0",
@@ -2402,6 +2734,11 @@
                 "tiletype": "0.1.x"
             }
         },
+        "media-typer": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.2.0.tgz",
+            "integrity": "sha1-2KBlITrf6qLnYyGitt2jb/YzWYQ="
+        },
         "mem": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
@@ -2409,6 +2746,26 @@
             "requires": {
                 "mimic-fn": "^1.0.0"
             }
+        },
+        "merge-descriptors": {
+            "version": "0.0.2",
+            "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-0.0.2.tgz",
+            "integrity": "sha1-w2pSp4FDdRPFcnXzndnTF1FKyMc="
+        },
+        "method-override": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/method-override/-/method-override-2.0.2.tgz",
+            "integrity": "sha1-AFMSeMeXiWQL8n6X4mo6Wh98ynM=",
+            "requires": {
+                "methods": "1.0.1",
+                "parseurl": "1.0.1",
+                "vary": "0.1.0"
+            }
+        },
+        "methods": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/methods/-/methods-1.0.1.tgz",
+            "integrity": "sha1-dbyRlD3/19oDfPPusO1zoAN80Us="
         },
         "millstone": {
             "version": "0.6.17",
@@ -2580,15 +2937,60 @@
             "resolved": "https://registry.npmjs.org/modestmaps/-/modestmaps-3.3.5.tgz",
             "integrity": "sha1-QCjaOg5qM7v3kqHAGxiql9cJZX4="
         },
+        "morgan": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.1.1.tgz",
+            "integrity": "sha1-zeRdLoB+vMQ5dFhG6oA5LmkJgUY=",
+            "requires": {
+                "bytes": "1.0.0"
+            }
+        },
         "ms": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
             "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
         },
+        "multiparty": {
+            "version": "3.2.9",
+            "resolved": "https://registry.npmjs.org/multiparty/-/multiparty-3.2.9.tgz",
+            "integrity": "sha1-xzNz6pwBLnd2zlvEDJNiZLa6LB4=",
+            "requires": {
+                "readable-stream": "~1.1.9",
+                "stream-counter": "~0.2.0"
+            },
+            "dependencies": {
+                "isarray": {
+                    "version": "0.0.1",
+                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                    "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+                },
+                "readable-stream": {
+                    "version": "1.1.14",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+                    "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+                    "requires": {
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.1",
+                        "isarray": "0.0.1",
+                        "string_decoder": "~0.10.x"
+                    }
+                },
+                "string_decoder": {
+                    "version": "0.10.31",
+                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                    "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+                }
+            }
+        },
         "nan": {
             "version": "2.5.1",
             "resolved": "https://registry.npmjs.org/nan/-/nan-2.5.1.tgz",
             "integrity": "sha1-1bAWkSUzJql6K77p5hxV2NYDUeI="
+        },
+        "native-or-bluebird": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/native-or-bluebird/-/native-or-bluebird-1.1.2.tgz",
+            "integrity": "sha1-OSHhECMtHreQ89rGG7NwUxx9NW4="
         },
         "needle": {
             "version": "2.2.4",
@@ -2614,6 +3016,11 @@
                     "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
                 }
             }
+        },
+        "negotiator": {
+            "version": "0.4.6",
+            "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.4.6.tgz",
+            "integrity": "sha1-9F+vn6gz7TylElDqmn3fxCZ6RLM="
         },
         "node-pre-gyp": {
             "version": "0.10.3",
@@ -2746,6 +3153,11 @@
             "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
             "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
         },
+        "on-headers": {
+            "version": "0.0.0",
+            "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-0.0.0.tgz",
+            "integrity": "sha1-7igX+DRDJXhc2cLfKyQrvBfK9MQ="
+        },
         "once": {
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -2851,6 +3263,11 @@
             "resolved": "https://registry.npmjs.org/parse5/-/parse5-1.5.1.tgz",
             "integrity": "sha1-m387DeMr543CQBsXVzzK8Pb1nZQ="
         },
+        "parseurl": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.0.1.tgz",
+            "integrity": "sha1-Llfc5u/dN8NRhwEDCUTCK/OIt7Q="
+        },
         "path-exists": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
@@ -2873,6 +3290,11 @@
             "requires": {
                 "pify": "^2.0.0"
             }
+        },
+        "pause": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/pause/-/pause-0.0.1.tgz",
+            "integrity": "sha1-HUCLP9t2kjuVQ9lvtMnf1TXZy10="
         },
         "performance-now": {
             "version": "0.2.0",
@@ -2899,6 +3321,14 @@
             "resolved": "https://registry.npmjs.org/protozero/-/protozero-1.5.1.tgz",
             "integrity": "sha1-Wiffb7bh7XQ/UQgSrnbAgvWxZjg="
         },
+        "proxy-addr": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.0.1.tgz",
+            "integrity": "sha1-x8Vm1etOP61n7rnHfFVYzMObiKg=",
+            "requires": {
+                "ipaddr.js": "0.1.2"
+            }
+        },
         "pseudomap": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
@@ -2913,6 +3343,32 @@
             "version": "0.4.2",
             "resolved": "https://registry.npmjs.org/qs/-/qs-0.4.2.tgz",
             "integrity": "sha1-PKxMhh43GoycR3CsI82o3mObjl8="
+        },
+        "rand-token": {
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/rand-token/-/rand-token-0.2.1.tgz",
+            "integrity": "sha1-3GfIEjMGyRInstw/W+pz0wE3YiY="
+        },
+        "range-parser": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.0.0.tgz",
+            "integrity": "sha1-pLJkz+C+XONqvjdlrJwqJIdG28A="
+        },
+        "raw-body": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-1.2.2.tgz",
+            "integrity": "sha1-DGjh7ijP7X26SCIjSuxgeEYcvB8=",
+            "requires": {
+                "bytes": "1",
+                "iconv-lite": "0.4.3"
+            },
+            "dependencies": {
+                "iconv-lite": {
+                    "version": "0.4.3",
+                    "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.3.tgz",
+                    "integrity": "sha1-nniHeTt2nMaV6yLSVGpP0tebeh4="
+                }
+            }
         },
         "rc": {
             "version": "1.2.8",
@@ -3007,6 +3463,14 @@
             "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
             "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE="
         },
+        "response-time": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/response-time/-/response-time-2.0.0.tgz",
+            "integrity": "sha1-Zcs5/VDeL0/9vdKF8YVZZr1vyzY=",
+            "requires": {
+                "on-headers": "0.0.0"
+            }
+        },
         "rimraf": {
             "version": "2.5.2",
             "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.2.tgz",
@@ -3014,6 +3478,11 @@
             "requires": {
                 "glob": "^7.0.0"
             }
+        },
+        "rndm": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/rndm/-/rndm-1.2.0.tgz",
+            "integrity": "sha1-8z/pz7Urv9UgqhgyO8ZdsRCht2w="
         },
         "safe-buffer": {
             "version": "5.1.2",
@@ -3030,10 +3499,75 @@
             "resolved": "https://registry.npmjs.org/sax/-/sax-0.6.1.tgz",
             "integrity": "sha1-VjsZx8HeiS4Jv8Ty/DDjwn8JUrk="
         },
+        "scmp": {
+            "version": "0.0.3",
+            "resolved": "https://registry.npmjs.org/scmp/-/scmp-0.0.3.tgz",
+            "integrity": "sha1-NkjfLXKUZB5/eGc//CloHZutkHM="
+        },
         "semver": {
             "version": "4.3.2",
             "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.2.tgz",
             "integrity": "sha1-x6BxWKgL7dBSNVt3DYLWZA+AO+c="
+        },
+        "send": {
+            "version": "0.4.3",
+            "resolved": "https://registry.npmjs.org/send/-/send-0.4.3.tgz",
+            "integrity": "sha1-lieyO3cH+/Y3ODHKxXkzMLWUtkA=",
+            "requires": {
+                "debug": "1.0.2",
+                "escape-html": "1.0.1",
+                "finished": "1.2.2",
+                "fresh": "0.2.2",
+                "mime": "1.2.11",
+                "range-parser": "~1.0.0"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-1.0.2.tgz",
+                    "integrity": "sha1-OElZHBDM5khHbDx8Li40FttZY8Q=",
+                    "requires": {
+                        "ms": "0.6.2"
+                    }
+                },
+                "mime": {
+                    "version": "1.2.11",
+                    "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz",
+                    "integrity": "sha1-WCA+7Ybjpe8XrtK32evUfwpg3RA="
+                },
+                "ms": {
+                    "version": "0.6.2",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz",
+                    "integrity": "sha1-2JwhJMb9wTU9Zai3e/GqxLGTcIw="
+                }
+            }
+        },
+        "serve-favicon": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/serve-favicon/-/serve-favicon-2.0.1.tgz",
+            "integrity": "sha1-SCaXXZ8XPKOkFY6WmBYfdd7Hr+w=",
+            "requires": {
+                "fresh": "0.2.2"
+            }
+        },
+        "serve-index": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/serve-index/-/serve-index-1.1.2.tgz",
+            "integrity": "sha1-B0K0gJmCV1OcLSrMbKH0qvJn+XI=",
+            "requires": {
+                "accepts": "1.0.3",
+                "batch": "0.5.1"
+            }
+        },
+        "serve-static": {
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.2.3.tgz",
+            "integrity": "sha1-k87Lw0Dweey4WJKB0dwxwmwM0Vg=",
+            "requires": {
+                "escape-html": "1.0.1",
+                "parseurl": "1.0.1",
+                "send": "0.4.3"
+            }
         },
         "set-blocking": {
             "version": "2.0.0",
@@ -3855,6 +4389,37 @@
             "resolved": "https://registry.npmjs.org/step/-/step-0.0.5.tgz",
             "integrity": "sha1-XmYvFfm6Ls6cOpsOJVPRmGtrpEw="
         },
+        "stream-counter": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/stream-counter/-/stream-counter-0.2.0.tgz",
+            "integrity": "sha1-3tJmVWMZyLDiIoErnPOyb6fZR94=",
+            "requires": {
+                "readable-stream": "~1.1.8"
+            },
+            "dependencies": {
+                "isarray": {
+                    "version": "0.0.1",
+                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                    "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+                },
+                "readable-stream": {
+                    "version": "1.1.14",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+                    "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+                    "requires": {
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.1",
+                        "isarray": "0.0.1",
+                        "string_decoder": "~0.10.x"
+                    }
+                },
+                "string_decoder": {
+                    "version": "0.10.31",
+                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                    "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+                }
+            }
+        },
         "string-width": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
@@ -4032,10 +4597,42 @@
                 "prelude-ls": "~1.1.2"
             }
         },
+        "type-is": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.3.1.tgz",
+            "integrity": "sha1-pnibWlITgomt4e+PbZ8odP/XC2s=",
+            "requires": {
+                "media-typer": "0.2.0",
+                "mime-types": "1.0.0"
+            },
+            "dependencies": {
+                "mime-types": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-1.0.0.tgz",
+                    "integrity": "sha1-antKavLn2S+Xr+A/BHx4AejwAdI="
+                }
+            }
+        },
         "uglify-js": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-1.0.2.tgz",
             "integrity": "sha1-KElMx3wmBC1AZdc3NjkdeEF9aAo="
+        },
+        "uid-safe": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/uid-safe/-/uid-safe-1.1.0.tgz",
+            "integrity": "sha1-WNbF2r+N+9jVKDSDmAbAP9YUMjI=",
+            "requires": {
+                "base64-url": "1.2.1",
+                "native-or-bluebird": "~1.1.2"
+            },
+            "dependencies": {
+                "base64-url": {
+                    "version": "1.2.1",
+                    "resolved": "https://registry.npmjs.org/base64-url/-/base64-url-1.2.1.tgz",
+                    "integrity": "sha1-GZ/WYXAqDnt9yubgaYuwicUvbXg="
+                }
+            }
         },
         "underscore": {
             "version": "1.6.0",
@@ -4046,6 +4643,11 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
             "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+        },
+        "utils-merge": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz",
+            "integrity": "sha1-ApT7kiu5N1FTVBxPcJYjHyh8ivg="
         },
         "uuid": {
             "version": "3.3.2",
@@ -4060,6 +4662,11 @@
                 "spdx-correct": "^3.0.0",
                 "spdx-expression-parse": "^3.0.0"
             }
+        },
+        "vary": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/vary/-/vary-0.1.0.tgz",
+            "integrity": "sha1-3wlFiZ6TwMxb0YzIMh2dIedPYXY="
         },
         "verror": {
             "version": "1.10.0",
@@ -4077,6 +4684,11 @@
                     "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
                 }
             }
+        },
+        "vhost": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/vhost/-/vhost-2.0.0.tgz",
+            "integrity": "sha1-HiZ3C9D86GxAlFWR5vKExokXkeI="
         },
         "wax": {
             "version": "6.4.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3031,9 +3031,9 @@
             "integrity": "sha1-VjsZx8HeiS4Jv8Ty/DDjwn8JUrk="
         },
         "semver": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-4.1.0.tgz",
-            "integrity": "sha1-vICp/2hTKBQ2LMPP2jx7de2cMhw="
+            "version": "4.3.2",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.2.tgz",
+            "integrity": "sha1-x6BxWKgL7dBSNVt3DYLWZA+AO+c="
         },
         "set-blocking": {
             "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
         "request": "2.81.0",
         "rimraf": "2.5.2",
         "sax": "0.6.1",
-        "semver": "4.1.0",
+        "semver": "4.3.2",
         "sphericalmercator": "1.0.2",
         "sqlite3": "3.1.13",
         "step": "0.0.5",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
         "carto": "0.18.2",
         "chrono": "1.0.1",
         "connect": "1.9.2",
-        "express": "2.5.11",
+        "express": "3.11.0",
         "generic-pool": "2.4.1",
         "glob": "7.0.0",
         "jquery": "3.3.1",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
         "express": "2.5.11",
         "generic-pool": "2.4.1",
         "glob": "7.0.0",
-        "jquery": "2.1.0",
+        "jquery": "3.3.1",
         "jsdom": "7.0.0",
         "mapnik": "3.6.2",
         "mbtiles": "0.8.2",


### PR DESCRIPTION
- Update semver from 4.1.0 to 4.3.2
- Update jquery from 2.1.0 to 3.3.1
- Update express from 2.5.11 to 3.11.0

Mocha tests all passed. Manually tested in app as well.