### PR TITLE
Updating semver from 5.0.0 to 5.6.0.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1608,9 +1608,9 @@
             },
             "dependencies": {
                 "acorn": {
-                    "version": "6.0.6",
-                    "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.0.6.tgz",
-                    "integrity": "sha512-5M3G/A4uBSMIlfJ+h9W125vJvPFH/zirISsW5qfxF5YzEvXJCtolLoQvM5yZft0DvMcUrPGKPOlgEu55I6iUtA=="
+                    "version": "6.0.7",
+                    "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.0.7.tgz",
+                    "integrity": "sha512-HNJNgE60C9eOTgn974Tlp3dpLZdUr+SoxxDwPaY9J/kDNOLQTkaDgwBUXAF4SSsrAwD9RpdxuHK/EbuF+W9Ahw=="
                 },
                 "acorn-globals": {
                     "version": "4.3.0",
@@ -2631,13 +2631,6 @@
             "requires": {
                 "lodash": "^4.11.0",
                 "semver": "^5.1.0"
-            },
-            "dependencies": {
-                "semver": {
-                    "version": "5.6.0",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
-                    "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg=="
-                }
             }
         },
         "mapnik-vector-tile": {
@@ -2889,13 +2882,6 @@
                 "rimraf": "^2.6.1",
                 "semver": "^5.3.0",
                 "tar": "^4"
-            },
-            "dependencies": {
-                "semver": {
-                    "version": "5.6.0",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
-                    "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg=="
-                }
             }
         },
         "nopt": {
@@ -2962,9 +2948,9 @@
             "integrity": "sha512-3iuY4N5dhgMpCUrOVnuAdGrgxVqV2cJpM+XNccjR2DKOB1RUP0aA+wGXEiNziG/UKboFyGBIoKOaNlJxx8bciQ=="
         },
         "nwsapi": {
-            "version": "2.0.9",
-            "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.0.9.tgz",
-            "integrity": "sha512-nlWFSCTYQcHk/6A9FFnfhKc14c3aFhfdNBXgo8Qgi9QTBu/qg3Ww+Uiz9wMzXd1T8GFxPc2QIHB6Qtf2XFryFQ=="
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.1.0.tgz",
+            "integrity": "sha512-ZG3bLAvdHmhIjaQ/Db1qvBxsGvFMLIRpQszyqbg31VJ53UP++uZX1/gf3Ut96pdwN9AuDwlMqIYLm0UPCdUeHg=="
         },
         "oauth-sign": {
             "version": "0.9.0",
@@ -3338,9 +3324,9 @@
             }
         },
         "semver": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-5.0.0.tgz",
-            "integrity": "sha1-+W/Q+B6nHsExrOrCZyXO8qJV3AE="
+            "version": "5.6.0",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
+            "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg=="
         },
         "send": {
             "version": "0.16.2",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
         "request": "2.88.0",
         "rimraf": "2.6.3",
         "sax": "1.2.4",
-        "semver": "5.0.0",
+        "semver": "5.6.0",
         "sphericalmercator": "1.0.2",
         "sqlite3": "3.1.13",
         "step": "1.0.0",

--- a/servers/Route.bones
+++ b/servers/Route.bones
@@ -11,7 +11,6 @@ servers['Route'].augment({
             require.resolve('../assets/js/colorpicker.classic.js'),
             require.resolve('../assets/js/mustache.js'),
             require.resolve('../assets/js/jquery.ui.js'),
-            require.resolve('semver/semver.browser.js'),
             require.resolve('chrono/lib/chrono.js'),
             require.resolve('modestmaps/modestmaps.js'),
             require.resolve('wax/dist/wax.mm.min.js'),


### PR DESCRIPTION
Issue #2658. There was no more support for the browser version of semver (build in <v5.0.0). It was being included in Route.bones for use on the browser but never being used in the browser so I removed semver from Route.bones. Everything seems to work OK without it being there.