### PR TITLE
Update mapnik to v3.7.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1708,31 +1708,74 @@
             }
         },
         "mapnik": {
-            "version": "3.6.2",
-            "resolved": "https://registry.npmjs.org/mapnik/-/mapnik-3.6.2.tgz",
-            "integrity": "sha1-Scqqt9l8BNQ5mzLmqY7CsWWfIYw=",
+            "version": "3.7.2",
+            "resolved": "https://registry.npmjs.org/mapnik/-/mapnik-3.7.2.tgz",
+            "integrity": "sha512-mdpXpSds+Mi+1fABf2spMOQ+lnrJqE3isBMHDxCisZOPvppsTKAyGB9i8cXT+qbewcLgTcezgA8+SbeQQr/v9g==",
             "requires": {
-                "mapnik-vector-tile": "1.4.0",
-                "nan": "~2.5.0",
+                "mapnik-vector-tile": "1.6.1",
+                "nan": "~2.8.0",
                 "node-pre-gyp": "~0.6.30",
                 "protozero": "1.5.1"
             },
             "dependencies": {
                 "node-pre-gyp": {
-                    "version": "0.6.36",
+                    "version": "0.6.39",
                     "bundled": true,
                     "requires": {
+                        "detect-libc": "^1.0.2",
+                        "hawk": "3.1.3",
                         "mkdirp": "^0.5.1",
                         "nopt": "^4.0.1",
                         "npmlog": "^4.0.2",
                         "rc": "^1.1.7",
-                        "request": "^2.81.0",
+                        "request": "2.81.0",
                         "rimraf": "^2.6.1",
                         "semver": "^5.3.0",
                         "tar": "^2.2.1",
                         "tar-pack": "^3.4.0"
                     },
                     "dependencies": {
+                        "detect-libc": {
+                            "version": "1.0.3",
+                            "bundled": true
+                        },
+                        "hawk": {
+                            "version": "3.1.3",
+                            "bundled": true,
+                            "requires": {
+                                "boom": "2.x.x",
+                                "cryptiles": "2.x.x",
+                                "hoek": "2.x.x",
+                                "sntp": "1.x.x"
+                            },
+                            "dependencies": {
+                                "boom": {
+                                    "version": "2.10.1",
+                                    "bundled": true,
+                                    "requires": {
+                                        "hoek": "2.x.x"
+                                    }
+                                },
+                                "cryptiles": {
+                                    "version": "2.0.5",
+                                    "bundled": true,
+                                    "requires": {
+                                        "boom": "2.x.x"
+                                    }
+                                },
+                                "hoek": {
+                                    "version": "2.16.3",
+                                    "bundled": true
+                                },
+                                "sntp": {
+                                    "version": "1.0.9",
+                                    "bundled": true,
+                                    "requires": {
+                                        "hoek": "2.x.x"
+                                    }
+                                }
+                            }
+                        },
                         "mkdirp": {
                             "version": "0.5.1",
                             "bundled": true,
@@ -1755,11 +1798,11 @@
                             },
                             "dependencies": {
                                 "abbrev": {
-                                    "version": "1.1.0",
+                                    "version": "1.1.1",
                                     "bundled": true
                                 },
                                 "osenv": {
-                                    "version": "0.1.4",
+                                    "version": "0.1.5",
                                     "bundled": true,
                                     "requires": {
                                         "os-homedir": "^1.0.0",
@@ -1779,7 +1822,7 @@
                             }
                         },
                         "npmlog": {
-                            "version": "4.1.0",
+                            "version": "4.1.2",
                             "bundled": true,
                             "requires": {
                                 "are-we-there-yet": "~1.1.2",
@@ -1801,15 +1844,15 @@
                                             "bundled": true
                                         },
                                         "readable-stream": {
-                                            "version": "2.2.11",
+                                            "version": "2.3.6",
                                             "bundled": true,
                                             "requires": {
                                                 "core-util-is": "~1.0.0",
-                                                "inherits": "~2.0.1",
+                                                "inherits": "~2.0.3",
                                                 "isarray": "~1.0.0",
-                                                "process-nextick-args": "~1.0.6",
-                                                "safe-buffer": "~5.0.1",
-                                                "string_decoder": "~1.0.0",
+                                                "process-nextick-args": "~2.0.0",
+                                                "safe-buffer": "~5.1.1",
+                                                "string_decoder": "~1.1.1",
                                                 "util-deprecate": "~1.0.1"
                                             },
                                             "dependencies": {
@@ -1826,18 +1869,18 @@
                                                     "bundled": true
                                                 },
                                                 "process-nextick-args": {
-                                                    "version": "1.0.7",
+                                                    "version": "2.0.0",
                                                     "bundled": true
                                                 },
                                                 "safe-buffer": {
-                                                    "version": "5.0.1",
+                                                    "version": "5.1.1",
                                                     "bundled": true
                                                 },
                                                 "string_decoder": {
-                                                    "version": "1.0.2",
+                                                    "version": "1.1.1",
                                                     "bundled": true,
                                                     "requires": {
-                                                        "safe-buffer": "~5.0.1"
+                                                        "safe-buffer": "~5.1.0"
                                                     }
                                                 },
                                                 "util-deprecate": {
@@ -1867,7 +1910,7 @@
                                     },
                                     "dependencies": {
                                         "aproba": {
-                                            "version": "1.1.2",
+                                            "version": "1.2.0",
                                             "bundled": true
                                         },
                                         "has-unicode": {
@@ -1939,7 +1982,7 @@
                             }
                         },
                         "rc": {
-                            "version": "1.2.1",
+                            "version": "1.2.6",
                             "bundled": true,
                             "requires": {
                                 "deep-extend": "~0.4.0",
@@ -1953,7 +1996,7 @@
                                     "bundled": true
                                 },
                                 "ini": {
-                                    "version": "1.3.4",
+                                    "version": "1.3.5",
                                     "bundled": true
                                 },
                                 "minimist": {
@@ -1999,7 +2042,7 @@
                                     "bundled": true
                                 },
                                 "aws4": {
-                                    "version": "1.6.0",
+                                    "version": "1.7.0",
                                     "bundled": true
                                 },
                                 "caseless": {
@@ -2007,7 +2050,7 @@
                                     "bundled": true
                                 },
                                 "combined-stream": {
-                                    "version": "1.0.5",
+                                    "version": "1.0.6",
                                     "bundled": true,
                                     "requires": {
                                         "delayed-stream": "~1.0.0"
@@ -2083,43 +2126,6 @@
                                         }
                                     }
                                 },
-                                "hawk": {
-                                    "version": "3.1.3",
-                                    "bundled": true,
-                                    "requires": {
-                                        "boom": "2.x.x",
-                                        "cryptiles": "2.x.x",
-                                        "hoek": "2.x.x",
-                                        "sntp": "1.x.x"
-                                    },
-                                    "dependencies": {
-                                        "boom": {
-                                            "version": "2.10.1",
-                                            "bundled": true,
-                                            "requires": {
-                                                "hoek": "2.x.x"
-                                            }
-                                        },
-                                        "cryptiles": {
-                                            "version": "2.0.5",
-                                            "bundled": true,
-                                            "requires": {
-                                                "boom": "2.x.x"
-                                            }
-                                        },
-                                        "hoek": {
-                                            "version": "2.16.3",
-                                            "bundled": true
-                                        },
-                                        "sntp": {
-                                            "version": "1.0.9",
-                                            "bundled": true,
-                                            "requires": {
-                                                "hoek": "2.x.x"
-                                            }
-                                        }
-                                    }
-                                },
                                 "http-signature": {
                                     "version": "1.1.1",
                                     "bundled": true,
@@ -2134,13 +2140,13 @@
                                             "bundled": true
                                         },
                                         "jsprim": {
-                                            "version": "1.4.0",
+                                            "version": "1.4.1",
                                             "bundled": true,
                                             "requires": {
                                                 "assert-plus": "1.0.0",
-                                                "extsprintf": "1.0.2",
+                                                "extsprintf": "1.3.0",
                                                 "json-schema": "0.2.3",
-                                                "verror": "1.3.6"
+                                                "verror": "1.10.0"
                                             },
                                             "dependencies": {
                                                 "assert-plus": {
@@ -2148,7 +2154,7 @@
                                                     "bundled": true
                                                 },
                                                 "extsprintf": {
-                                                    "version": "1.0.2",
+                                                    "version": "1.3.0",
                                                     "bundled": true
                                                 },
                                                 "json-schema": {
@@ -2156,16 +2162,24 @@
                                                     "bundled": true
                                                 },
                                                 "verror": {
-                                                    "version": "1.3.6",
+                                                    "version": "1.10.0",
                                                     "bundled": true,
                                                     "requires": {
-                                                        "extsprintf": "1.0.2"
+                                                        "assert-plus": "^1.0.0",
+                                                        "core-util-is": "1.0.2",
+                                                        "extsprintf": "^1.2.0"
+                                                    },
+                                                    "dependencies": {
+                                                        "core-util-is": {
+                                                            "version": "1.0.2",
+                                                            "bundled": true
+                                                        }
                                                     }
                                                 }
                                             }
                                         },
                                         "sshpk": {
-                                            "version": "1.13.1",
+                                            "version": "1.14.1",
                                             "bundled": true,
                                             "requires": {
                                                 "asn1": "~0.2.3",
@@ -2243,14 +2257,14 @@
                                     "bundled": true
                                 },
                                 "mime-types": {
-                                    "version": "2.1.15",
+                                    "version": "2.1.18",
                                     "bundled": true,
                                     "requires": {
-                                        "mime-db": "~1.27.0"
+                                        "mime-db": "~1.33.0"
                                     },
                                     "dependencies": {
                                         "mime-db": {
-                                            "version": "1.27.0",
+                                            "version": "1.33.0",
                                             "bundled": true
                                         }
                                     }
@@ -2268,7 +2282,7 @@
                                     "bundled": true
                                 },
                                 "safe-buffer": {
-                                    "version": "5.1.0",
+                                    "version": "5.1.1",
                                     "bundled": true
                                 },
                                 "stringstream": {
@@ -2276,7 +2290,7 @@
                                     "bundled": true
                                 },
                                 "tough-cookie": {
-                                    "version": "2.3.2",
+                                    "version": "2.3.4",
                                     "bundled": true,
                                     "requires": {
                                         "punycode": "^1.4.1"
@@ -2296,13 +2310,13 @@
                                     }
                                 },
                                 "uuid": {
-                                    "version": "3.0.1",
+                                    "version": "3.2.1",
                                     "bundled": true
                                 }
                             }
                         },
                         "rimraf": {
-                            "version": "2.6.1",
+                            "version": "2.6.2",
                             "bundled": true,
                             "requires": {
                                 "glob": "^7.0.5"
@@ -2350,15 +2364,15 @@
                                             },
                                             "dependencies": {
                                                 "brace-expansion": {
-                                                    "version": "1.1.7",
+                                                    "version": "1.1.11",
                                                     "bundled": true,
                                                     "requires": {
-                                                        "balanced-match": "^0.4.1",
+                                                        "balanced-match": "^1.0.0",
                                                         "concat-map": "0.0.1"
                                                     },
                                                     "dependencies": {
                                                         "balanced-match": {
-                                                            "version": "0.4.2",
+                                                            "version": "1.0.0",
                                                             "bundled": true
                                                         },
                                                         "concat-map": {
@@ -2391,7 +2405,7 @@
                             }
                         },
                         "semver": {
-                            "version": "5.3.0",
+                            "version": "5.5.0",
                             "bundled": true
                         },
                         "tar": {
@@ -2433,7 +2447,7 @@
                             }
                         },
                         "tar-pack": {
-                            "version": "3.4.0",
+                            "version": "3.4.1",
                             "bundled": true,
                             "requires": {
                                 "debug": "^2.2.0",
@@ -2447,7 +2461,7 @@
                             },
                             "dependencies": {
                                 "debug": {
-                                    "version": "2.6.8",
+                                    "version": "2.6.9",
                                     "bundled": true,
                                     "requires": {
                                         "ms": "2.0.0"
@@ -2500,15 +2514,15 @@
                                             },
                                             "dependencies": {
                                                 "brace-expansion": {
-                                                    "version": "1.1.7",
+                                                    "version": "1.1.11",
                                                     "bundled": true,
                                                     "requires": {
-                                                        "balanced-match": "^0.4.1",
+                                                        "balanced-match": "^1.0.0",
                                                         "concat-map": "0.0.1"
                                                     },
                                                     "dependencies": {
                                                         "balanced-match": {
-                                                            "version": "0.4.2",
+                                                            "version": "1.0.0",
                                                             "bundled": true
                                                         },
                                                         "concat-map": {
@@ -2535,15 +2549,15 @@
                                     }
                                 },
                                 "readable-stream": {
-                                    "version": "2.2.11",
+                                    "version": "2.3.6",
                                     "bundled": true,
                                     "requires": {
                                         "core-util-is": "~1.0.0",
-                                        "inherits": "~2.0.1",
+                                        "inherits": "~2.0.3",
                                         "isarray": "~1.0.0",
-                                        "process-nextick-args": "~1.0.6",
-                                        "safe-buffer": "~5.0.1",
-                                        "string_decoder": "~1.0.0",
+                                        "process-nextick-args": "~2.0.0",
+                                        "safe-buffer": "~5.1.1",
+                                        "string_decoder": "~1.1.1",
                                         "util-deprecate": "~1.0.1"
                                     },
                                     "dependencies": {
@@ -2560,18 +2574,18 @@
                                             "bundled": true
                                         },
                                         "process-nextick-args": {
-                                            "version": "1.0.7",
+                                            "version": "2.0.0",
                                             "bundled": true
                                         },
                                         "safe-buffer": {
-                                            "version": "5.0.1",
+                                            "version": "5.1.1",
                                             "bundled": true
                                         },
                                         "string_decoder": {
-                                            "version": "1.0.2",
+                                            "version": "1.1.1",
                                             "bundled": true,
                                             "requires": {
-                                                "safe-buffer": "~5.0.1"
+                                                "safe-buffer": "~5.1.0"
                                             }
                                         },
                                         "util-deprecate": {
@@ -2600,9 +2614,9 @@
             }
         },
         "mapnik-vector-tile": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/mapnik-vector-tile/-/mapnik-vector-tile-1.4.0.tgz",
-            "integrity": "sha1-9GdCUUzTrTVUxdZAYUgE/pvrSeU="
+            "version": "1.6.1",
+            "resolved": "https://registry.npmjs.org/mapnik-vector-tile/-/mapnik-vector-tile-1.6.1.tgz",
+            "integrity": "sha1-Pf8n1eTx/MZH1ljqislZEh8zn1k="
         },
         "mbtiles": {
             "version": "0.8.2",
@@ -2814,9 +2828,9 @@
             "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
         },
         "nan": {
-            "version": "2.5.1",
-            "resolved": "https://registry.npmjs.org/nan/-/nan-2.5.1.tgz",
-            "integrity": "sha1-1bAWkSUzJql6K77p5hxV2NYDUeI="
+            "version": "2.8.0",
+            "resolved": "https://registry.npmjs.org/nan/-/nan-2.8.0.tgz",
+            "integrity": "sha1-7XFfP+neArV6XmJS2QqWZ14fCFo="
         },
         "needle": {
             "version": "2.2.4",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
         "glob": "7.1.3",
         "jquery": "3.3.1",
         "jsdom": "13.2.0",
-        "mapnik": "3.6.2",
+        "mapnik": "^3.7.2",
         "mbtiles": "0.8.2",
         "millstone": "0.6.17",
         "mkdirp": "0.5.1",


### PR DESCRIPTION
Fixes #2636 
- Update package.json dependency to mapnik v3.7.2.
- No issues found, no fixes required.