### PR TITLE
Updated tilelive-mapnik to the mapbox scope and to v1.0.0.

### DIFF
--- a/commands/export.bones
+++ b/commands/export.bones
@@ -410,7 +410,7 @@ command.prototype.tilelive = function (project, callback) {
     try { require(this.opts.format).registerProtocols(tilelive); }
     catch(err) {}
 
-    require('tilelive-mapnik').registerProtocols(tilelive);
+    require('@mapbox/tilelive-mapnik').registerProtocols(tilelive);
 
     // Copy the bounds so that we can modify them if we need to split the export
     var bboxes = [ project.mml.bounds.slice(0) ];

--- a/index.js
+++ b/index.js
@@ -33,7 +33,7 @@ if (existsSync(config)) {
     argv.config = argv.config || config;
 }
 
-require('tilelive-mapnik').registerProtocols(require('tilelive'));
+require('@mapbox/tilelive-mapnik').registerProtocols(require('tilelive'));
 require('@mapbox/mbtiles').registerProtocols(require('tilelive'));
 
 require('bones').load(__dirname);

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,29 @@
             "resolved": "https://registry.npmjs.org/@mapbox/sphericalmercator/-/sphericalmercator-1.1.0.tgz",
             "integrity": "sha512-pEsfZyG4OMThlfFQbCte4gegvHUjxXCjz0KZ4Xk8NdOYTQBLflj6U8PL05RPAiuRAMAQNUUKJuL6qYZ5Y4kAWA=="
         },
+        "@mapbox/tilelive-mapnik": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/@mapbox/tilelive-mapnik/-/tilelive-mapnik-1.0.0.tgz",
+            "integrity": "sha1-gdSALo+FBAaCAuH1SDFLQKB4/u8=",
+            "requires": {
+                "generic-pool": "~2.4.0",
+                "mapnik": "~3.7.0",
+                "mime": "~1.3.4",
+                "step": "~0.0.5"
+            },
+            "dependencies": {
+                "generic-pool": {
+                    "version": "2.4.6",
+                    "resolved": "https://registry.npmjs.org/generic-pool/-/generic-pool-2.4.6.tgz",
+                    "integrity": "sha1-8bVeVyFn26L+ddWqkeux6fcmQtc="
+                },
+                "step": {
+                    "version": "0.0.6",
+                    "resolved": "https://registry.npmjs.org/step/-/step-0.0.6.tgz",
+                    "integrity": "sha1-FD54SaXX0/SgiP4pr5SRUhbu7eI="
+                }
+            }
+        },
         "@mapbox/tiletype": {
             "version": "0.3.1",
             "resolved": "https://registry.npmjs.org/@mapbox/tiletype/-/tiletype-0.3.1.tgz",
@@ -384,6 +407,11 @@
                         "xml-name-validator": "^1.0.0",
                         "xmlhttprequest": ">= 1.6.0 < 2.0.0"
                     }
+                },
+                "mime": {
+                    "version": "1.2.4",
+                    "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.4.tgz",
+                    "integrity": "sha1-EbX9rynCUJJVF2uArVIClPXekrc="
                 },
                 "mkdirp": {
                     "version": "0.3.0",
@@ -3628,9 +3656,9 @@
             }
         },
         "mime": {
-            "version": "1.2.4",
-            "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.4.tgz",
-            "integrity": "sha1-EbX9rynCUJJVF2uArVIClPXekrc="
+            "version": "1.3.6",
+            "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.6.tgz",
+            "integrity": "sha1-WR2E02U6awtKO5343lqoEI5y5eA="
         },
         "mime-db": {
             "version": "1.38.0",
@@ -5014,40 +5042,6 @@
                     "version": "1.0.5",
                     "resolved": "https://registry.npmjs.org/sphericalmercator/-/sphericalmercator-1.0.5.tgz",
                     "integrity": "sha1-3cWgSeNg4ADQ+tn8IsQHGIJYSYA="
-                }
-            }
-        },
-        "tilelive-mapnik": {
-            "version": "0.6.18",
-            "resolved": "https://registry.npmjs.org/tilelive-mapnik/-/tilelive-mapnik-0.6.18.tgz",
-            "integrity": "sha1-fDja+3KALBEsW2PiKJZPQ4QB1fg=",
-            "requires": {
-                "generic-pool": "~2.4.0",
-                "mapnik": ">=3.2.0 && <4.0.0",
-                "mime": "~1.3.4",
-                "sphericalmercator": "~1.0.4",
-                "step": "~0.0.5"
-            },
-            "dependencies": {
-                "generic-pool": {
-                    "version": "2.4.6",
-                    "resolved": "https://registry.npmjs.org/generic-pool/-/generic-pool-2.4.6.tgz",
-                    "integrity": "sha1-8bVeVyFn26L+ddWqkeux6fcmQtc="
-                },
-                "mime": {
-                    "version": "1.3.6",
-                    "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.6.tgz",
-                    "integrity": "sha1-WR2E02U6awtKO5343lqoEI5y5eA="
-                },
-                "sphericalmercator": {
-                    "version": "1.0.5",
-                    "resolved": "https://registry.npmjs.org/sphericalmercator/-/sphericalmercator-1.0.5.tgz",
-                    "integrity": "sha1-3cWgSeNg4ADQ+tn8IsQHGIJYSYA="
-                },
-                "step": {
-                    "version": "0.0.6",
-                    "resolved": "https://registry.npmjs.org/step/-/step-0.0.6.tgz",
-                    "integrity": "sha1-FD54SaXX0/SgiP4pr5SRUhbu7eI="
                 }
             }
         },

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
         "glob": "7.1.3",
         "jquery": "3.3.1",
         "jsdom": "13.2.0",
-        "mapnik": "^3.7.2",
+        "mapnik": "~3.7.2",
         "@mapbox/mbtiles": "0.10.0",
         "millstone": "git://github.com/tilemill-project/millstone.git#v0.6.18",
         "mkdirp": "0.5.1",
@@ -58,7 +58,7 @@
         "sqlite3": "4.0.6",
         "step": "1.0.0",
         "tilelive": "git://github.com/florianf/tilelive.git",
-        "tilelive-mapnik": "0.6.18",
+        "@mapbox/tilelive-mapnik": "1.0.0",
         "underscore": "1.9.1",
         "wax": "6.4.2",
         "xmlhttprequest": "1.8.0"


### PR DESCRIPTION
Issue #2691: Updated tilelive-mapnik to the mapbox scope and to v1.0.0. Also updated mapnik to ~3.7.2 so that it matches to tilelive-mapnik (to be safe) since we can only have one version of mapnik.