### PR TITLE
Upgrading bones version.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -349,8 +349,8 @@
             }
         },
         "bones": {
-            "version": "git://github.com/tilemill-project/bones.git#f7900d9211ec77ffb0dcb89a101cbc597ce99a97",
-            "from": "git://github.com/tilemill-project/bones.git#1.3",
+            "version": "git://github.com/tilemill-project/bones.git#c1654a3abf579ba724786173ffea5605a8122c4a",
+            "from": "git://github.com/tilemill-project/bones.git#1.3.31",
             "requires": {
                 "backbone": "0.3.3",
                 "express": "~2.5.11",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
         "JSV": "4.0.2",
         "backbone": "1.4.0",
         "backbone-dirty": "1.1.3",
-        "bones": "git://github.com/tilemill-project/bones.git#1.3",
+        "bones": "git://github.com/tilemill-project/bones.git#1.3.31",
         "carto": "1.0.1",
         "chrono": "1.0.5",
         "connect": "3.6.6",


### PR DESCRIPTION
Issue #2685: Upgrading to version of bones that suppresses the irritating warnings during mocha tests.