### PR TITLE
Update to how the unique version is created and tested

### DIFF
--- a/commands/core.bones
+++ b/commands/core.bones
@@ -101,6 +101,8 @@ command.prototype.bootstrap = function(plugin, callback) {
     cartoRef.setVersion(mapnik.versions.mapnik);
 
     Bones.plugin.abilities = {
+        // Get the unique version (from the VERSION file) that will be used in the parens in the heading
+        // of the project settings page.
         version: (function() {
             try {
                 return _(fs.readFileSync(path.resolve(__dirname + '/../VERSION'),'utf8').split('\n')).compact();

--- a/lib/gitutil.js
+++ b/lib/gitutil.js
@@ -1,3 +1,5 @@
+// Create the VERSION file which will be read by commands/core.bones to populate the unique version
+// in the heading of the project settings page.
 var exec = require('child_process').exec;
 var fs = require('fs');
 var package_json = require('../package.json');
@@ -9,8 +11,8 @@ var child = exec('git describe --tags --always',
     } else {
         var hash = stdout;
         if (hash[0] == 'v') {
-            // git describe actually found a tag
-            var version_file = hash + hash.slice(1, -10).replace('-', '.') + '\n';
+            //var version_file = hash + hash.slice(1, -10).replace('-', '.') + '\n';
+            var version_file = hash;
             fs.writeFileSync('VERSION', version_file);
         } else {
             // no tag found likely due to shallow clone (--depth=N)

--- a/test/abilities.test.js
+++ b/test/abilities.test.js
@@ -25,11 +25,13 @@ it('GET should return JSON', function(done) {
         function(res) {
             var body = res.body.replace(/^\s*var\s+abilities\s*=\s*(.+?);?$/, '$1');
             var abilities = JSON.parse(body);
-            // travis does a shallow clone so the git version and hash will
-            // not be known, which is harmless
+            // travis does a shallow clone so the git version and hash will not be known, which is harmless
             if (!process.env.TRAVIS && !process.env.APPVEYOR) {
-                assert.ok(/v\d+.\d+.\d+-\d+-[a-z0-9]+/.test(abilities.version[0]),abilities.version[0]);
-                assert.ok(/\d+.\d+.\d+.\d+/.test(abilities.version[1]),abilities.version[1]);
+                // Checking to see if the unique version from the VERSION file is there. It is used
+                // to put the unique version (in parens) into the header of the project settings page.
+                assert.ok(/v\d+.\d+.\d+.*/.test(abilities.version[0]),abilities.version[0]);
+                // Removed the second version from gitutils.js since it is never used.
+                //assert.ok(/\d+.\d+.\d+.\d+/.test(abilities.version[1]),abilities.version[1]);
             }
             assert.ok(abilities.fonts.indexOf('Arial Regular') >= 0 ||
                       abilities.fonts.indexOf('DejaVu Sans Book') >= 0);


### PR DESCRIPTION
Update to how the unique version is created and tested to account for the fact that git will return different tag formats depending on whether there have been commits after the tag creation or not.