### PR TITLE
Created Docker support with postgis instance

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+.dockerignore
+node_modules
+npm-debug.log
+Dockerfile
+.git
+.gitignore
+utils
+test

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,28 @@
+# Build Stage
+FROM node:8.15 AS BUILD
+
+WORKDIR /usr/src/app
+# Copy content of git repo to container
+COPY ./package.json /usr/src/app/
+COPY ./package-lock.json /usr/src/app/
+
+RUN npm install --only=production && npm prune --production
+
+# Production Stage
+FROM node:8.15-slim
+
+# Copy tilemill and node modules to new container
+WORKDIR /usr/src/app
+COPY --chown=node:node --from=BUILD /usr/src/app/node_modules /usr/src/app/node_modules
+COPY --chown=node:node . /usr/src/app
+
+RUN chmod 777 startdocker.sh
+
+USER node
+# Export port for tiles
+EXPOSE 20008
+# Export port for webpage
+EXPOSE 20009
+
+CMD ["node", "/usr/src/app/index.js", "--listenHost=0.0.0.0"]
+

--- a/README.md
+++ b/README.md
@@ -43,7 +43,20 @@ Scripts have been created that will do most everything for you. They were writte
 
 [Full Installation instructions can be found in the TileMill Documentation](https://tilemill-project.github.io/tilemill/docs/install/).
 
+### Docker
+It is also possible to run tilemill as a docker container:
 
+    git clone https://github.com/tilemill-project/tilemill.git
+    cd tilemill
+    docker-compose up
+    
+This will host a docker container which uses the port 20008 and 20009 for tilemill, tilemill is then reachable under [http://localhost:20009](http://localhost:20009) .
+Additionally, a postgis instance is started as well which is reachable under 
+
+	host=localhost port=5432 user=docker password=docker dbname=gis
+
+Docker hosted volumes are used for the containers, hence if you want to use sqlite dbs you have to interact with those to get the dbs into the docker container.
+    
 # Build Status, Running Tests, Updating Documentation
 
 See CONTRIBUTING.md

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,33 @@
+version: "3.3"
+services:
+  postgis:
+    image: kartoza/postgis:9.6-2.4
+    volumes:
+      - postgisVolume:/var/lib/postgresql
+    environment:
+      - POSTGRES_USER=docker
+      - POSTGRES_PASS=docker
+      - ALLOW_IP_RANGE=0.0.0.0/0
+    ports:
+      - "5432:5432"
+
+  tilemill:
+    build:
+      context: ./
+    ports:
+      - "20008:20008"
+      - "20009:20009"
+    volumes:
+      - tilemillVolume:/home/node/
+    environment:
+      - PGPORT=5432
+      - PGHOST=postgis
+      - PGDATABASE=gis
+      - PGUSER=docker
+      - PGPASSWORD=docker    
+    depends_on:
+      - postgis
+
+volumes:
+  postgisVolume:
+  tilemillVolume:


### PR DESCRIPTION
Adapted README.md to indicate the new Docker support

Dockerbuild uses a two-stage build to keep a low memory footprint for the final container.
Actual data is stored in docker volumes, that way one can avoid trouble with SELinux and permissions.
No proxy is used to keep it simple.

Works on my system with _podman_ as well.