### PR TITLE
Fix Dockerfile RUN chmod command on missing file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,8 +16,6 @@ WORKDIR /usr/src/app
 COPY --chown=node:node --from=BUILD /usr/src/app/node_modules /usr/src/app/node_modules
 COPY --chown=node:node . /usr/src/app
 
-RUN chmod 777 startdocker.sh
-
 USER node
 # Export port for tiles
 EXPOSE 20008


### PR DESCRIPTION
As I read on #2748 there was originally a startdocker.sh file that was replaced with a CMD instruction. 
However, on the Dockerfile build we still have a RUN instruction that execute `chmod 777 starddtdocker.sh` 

This result in an error when you try to build the image: 
` chmod: cannot access 'starddtdocker.sh': No such file or directory`

I fix it by deleting the not used instruction anymore. 