### PR TITLE
package.json: substituted git:// with https://

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "url": "https://github.com/tilemill-project/tilemill",
     "repository": {
         "type": "git",
-        "url": "git://github.com/tilemill-project/tilemill.git"
+        "url": "https://github.com/tilemill-project/tilemill.git"
     },
     "contributors": [
         "Cory Sytsma <csytsma>",
@@ -35,7 +35,7 @@
         "JSV": "4.0.2",
         "backbone": "1.4.0",
         "backbone-dirty": "1.1.3",
-        "bones": "git://github.com/tilemill-project/bones.git#1.3.31",
+        "bones": "https://github.com/tilemill-project/bones.git#1.3.31",
         "carto": "1.0.1",
         "chrono": "1.0.5",
         "connect": "3.6.6",
@@ -46,7 +46,7 @@
         "jsdom": "13.2.0",
         "mapnik": "~3.7.2",
         "@mapbox/mbtiles": "0.10.0",
-        "millstone": "git://github.com/tilemill-project/millstone.git#v0.6.18",
+        "millstone": "https://github.com/tilemill-project/millstone.git#v0.6.18",
         "mkdirp": "0.5.1",
         "modestmaps": "3.3.5",
         "optimist": "0.6.1",
@@ -57,10 +57,10 @@
         "@mapbox/sphericalmercator": "1.1.0",
         "sqlite3": "4.0.6",
         "step": "1.0.0",
-        "tilelive": "git://github.com/tilemill-project/tilelive.git#v5.14.0",
+        "tilelive": "https://github.com/tilemill-project/tilelive.git#v5.14.0",
         "@mapbox/tilelive-mapnik": "1.0.0",
         "underscore": "1.9.1",
-        "wax": "git://github.com/tilemill-project/wax.git#v6.4.4",
+        "wax": "https://github.com/tilemill-project/wax.git#v6.4.4",
         "xmlhttprequest": "1.8.0"
     },
     "devDependencies": {


### PR DESCRIPTION
Behind a corporate firewall, sometimes fetching packages via ssh (git) does not work while via https does.