### PR TITLE
force amd64 in docker-compose to support m1 cpu

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,7 @@ services:
       - "5432:5432"
 
   tilemill:
+    platform: linux/amd64
     build:
       context: ./
     ports:


### PR DESCRIPTION
in order to start the docker stack on an apple m1 cpu device it is necessary to set the platform attribute - otherwise the build will fail with this error:
Failed to execute '/usr/local/bin/node /usr/local/lib/node_modules/npm/node_modules/node-gyp/bin/node-gyp.js configure --fallback-to-build --module=/usr/src/app/node_modules/mapnik/lib/binding/mapnik.node --module_name=mapnik --module_path=/usr/src/app/node_modules/mapnik/lib/binding' (1)